### PR TITLE
Reset terminal title on exit

### DIFF
--- a/cmd/qbt-tui/main.go
+++ b/cmd/qbt-tui/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/nickvanw/qbittorrent-tui/internal/api"
 	"github.com/nickvanw/qbittorrent-tui/internal/config"
 	"github.com/nickvanw/qbittorrent-tui/internal/logger"
+	"github.com/nickvanw/qbittorrent-tui/internal/ui/terminal"
 	"github.com/nickvanw/qbittorrent-tui/internal/ui/views"
 )
 
@@ -153,6 +154,11 @@ func run(cmd *cobra.Command, args []string) error {
 
 	// Create the program
 	p := tea.NewProgram(model, tea.WithAltScreen())
+
+	// Reset terminal title on exit if it was enabled
+	if cfg.UI.TerminalTitle.Enabled {
+		defer terminal.ResetTerminalTitle()
+	}
 
 	// Run the program
 	if _, err := p.Run(); err != nil {

--- a/internal/ui/terminal/title.go
+++ b/internal/ui/terminal/title.go
@@ -29,6 +29,12 @@ func SetTerminalTitle(title string) string {
 	return fmt.Sprintf("\033]0;%s\007", title)
 }
 
+// ResetTerminalTitle prints an escape sequence to reset the terminal title
+// This sets an empty title, allowing the terminal to restore its default behavior
+func ResetTerminalTitle() {
+	fmt.Print("\033]0;\007")
+}
+
 // formatSpeed formats bytes per second into plain text human-readable format
 // This is specifically for terminal titles and does not include any ANSI codes
 func formatSpeed(bytesPerSec int64) string {


### PR DESCRIPTION
## Summary
- Add `ResetTerminalTitle()` function that clears the terminal title using an empty OSC escape sequence
- Call reset on application exit when terminal title feature is enabled
- Fixes the issue where custom terminal title persists after quitting the app

## Test plan
- Enable terminal title in config
- Run qbt-tui and verify the title is set
- Quit the application with Ctrl+C or q
- Verify the terminal title is cleared/reset