### PR TITLE
Support qBittorrent 5.2.0 API-key authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -26,9 +26,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.24-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.24-
+          ${{ runner.os }}-go-1.26-
 
     - name: Download dependencies
       run: go mod download
@@ -50,7 +50,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -58,9 +58,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.24-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.24-
+          ${{ runner.os }}-go-1.26-
 
     - name: Download dependencies
       run: go mod download
@@ -107,7 +107,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -115,9 +115,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.24-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.24-
+          ${{ runner.os }}-go-1.26-
 
     - name: Download dependencies
       run: go mod download
@@ -151,7 +151,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Cache Go modules
       uses: actions/cache@v5
@@ -159,9 +159,9 @@ jobs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-1.24-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-1.26-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-1.24-
+          ${{ runner.os }}-go-1.26-
 
     - name: Download dependencies
       run: go mod download
@@ -191,7 +191,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.24'
+        go-version: '1.26'
 
     - name: Download dependencies
       run: go mod download

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v6
       with:
-        go-version: '1.25'
+        go-version: '1.26'
 
     - name: Run GoReleaser
       uses: goreleaser/goreleaser-action@v7

--- a/README.md
+++ b/README.md
@@ -57,6 +57,18 @@ password = "secret"
 refresh_interval = 3
 ```
 
+### Authentication
+
+Choose **either** `username` + `password` **or** `api_key` — not both. Mixing them causes startup to fail.
+
+API keys (qBittorrent 5.2.0+) are stateless and skip the login round-trip. Generate one in qBittorrent under **Preferences → WebUI → API Key**.
+
+```toml
+[server]
+url = "http://localhost:8080"
+api_key = "qbt_xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+```
+
 ### Environment Variables / CLI Options
 
 ```bash
@@ -64,9 +76,12 @@ refresh_interval = 3
 export QBT_SERVER_URL="http://localhost:8080"
 export QBT_SERVER_USERNAME="admin"
 export QBT_SERVER_PASSWORD="secret"
+# or, instead of USERNAME/PASSWORD:
+export QBT_SERVER_API_KEY="qbt_xxxxxxxxxxxxxxxxxxxxxxxxxxxx"
 
 # CLI
 qbt-tui --url http://localhost:8080 --username admin --password secret
+qbt-tui --url http://localhost:8080 --api-key qbt_xxxxxxxxxxxxxxxxxxxxxxxxxxxx
 qbt-tui --help  # See all options
 ```
 

--- a/cmd/qbt-tui/main.go
+++ b/cmd/qbt-tui/main.go
@@ -19,6 +19,7 @@ var (
 	serverURL  string
 	username   string
 	password   string
+	apiKey     string
 	refreshInt int
 	debugMode  bool
 	logFile    string
@@ -50,8 +51,9 @@ CONFIGURATION:
 
   Environment variables (prefix QBT_):
     QBT_SERVER_URL           qBittorrent WebUI URL
-    QBT_SERVER_USERNAME      qBittorrent username  
+    QBT_SERVER_USERNAME      qBittorrent username
     QBT_SERVER_PASSWORD      qBittorrent password
+    QBT_SERVER_API_KEY       qBittorrent API key (≥5.2.0, alternative to user/pass)
     QBT_UI_REFRESH_INTERVAL  Refresh interval in seconds (default: 3)
 
 EXAMPLES:
@@ -108,6 +110,7 @@ func init() {
 	rootCmd.Flags().StringVarP(&serverURL, "url", "u", "", "qBittorrent WebUI URL")
 	rootCmd.Flags().StringVar(&username, "username", "", "qBittorrent username")
 	rootCmd.Flags().StringVarP(&password, "password", "p", "", "qBittorrent password")
+	rootCmd.Flags().StringVar(&apiKey, "api-key", "", "qBittorrent API key (≥5.2.0, alternative to username/password)")
 
 	// UI configuration flags
 	rootCmd.Flags().IntVarP(&refreshInt, "refresh", "r", 3, "refresh interval in seconds (default: 3)")
@@ -138,14 +141,23 @@ func run(cmd *cobra.Command, args []string) error {
 	}
 	defer logger.Close()
 
-	// Create and connect API client
-	client, err := api.NewClient(cfg.Server.URL)
-	if err != nil {
-		return fmt.Errorf("failed to create API client: %w", err)
-	}
-
-	if err := client.Login(cfg.Server.Username, cfg.Server.Password); err != nil {
-		return fmt.Errorf("failed to connect to qBittorrent API: %w", err)
+	// Create and connect API client. API-key auth (qBittorrent ≥5.2.0) is
+	// stateless and skips the /auth/login round-trip; the docs forbid using
+	// API keys against /auth/login. Otherwise fall back to user/pass login.
+	var client *api.Client
+	if cfg.Server.APIKey != "" {
+		client, err = api.NewClientWithAPIKey(cfg.Server.URL, cfg.Server.APIKey)
+		if err != nil {
+			return fmt.Errorf("failed to create API client: %w", err)
+		}
+	} else {
+		client, err = api.NewClient(cfg.Server.URL)
+		if err != nil {
+			return fmt.Errorf("failed to create API client: %w", err)
+		}
+		if err := client.Login(cfg.Server.Username, cfg.Server.Password); err != nil {
+			return fmt.Errorf("failed to connect to qBittorrent API: %w", err)
+		}
 	}
 
 	// Initialize the main view with the API client

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -1,7 +1,7 @@
 version: '3'
 services:
   qbittorrent:
-    image: linuxserver/qbittorrent:latest
+    image: lscr.io/linuxserver/qbittorrent:5.2.0
     environment:
       - PUID=${PUID:-1000}
       - PGID=${PGID:-1000}

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -29,6 +29,22 @@ func isSuccessStatus(code int) bool {
 	return code >= 200 && code < 300
 }
 
+// bearerAuthTransport injects "Authorization: Bearer <key>" on every outgoing
+// request. Used for qBittorrent's stateless API-key auth (≥5.2.0). Per the
+// qBittorrent docs, API keys cannot be used against /api/v2/auth/login or
+// /api/v2/auth/logout, so a client built with this transport must not call
+// Login.
+type bearerAuthTransport struct {
+	key  string
+	base http.RoundTripper
+}
+
+func (t *bearerAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	clone := req.Clone(req.Context())
+	clone.Header.Set("Authorization", "Bearer "+t.key)
+	return t.base.RoundTrip(clone)
+}
+
 func NewClient(baseURL string) (*Client, error) {
 	jar, err := cookiejar.New(nil)
 	if err != nil {
@@ -40,6 +56,27 @@ func NewClient(baseURL string) (*Client, error) {
 		httpClient: &http.Client{
 			Jar:     jar,
 			Timeout: 10 * time.Second,
+		},
+	}, nil
+}
+
+// NewClientWithAPIKey returns a Client that authenticates via qBittorrent's
+// stateless API-key mechanism (≥5.2.0). The key is sent as an
+// "Authorization: Bearer <key>" header on every request. Callers must not
+// invoke Login on a client built this way — qBittorrent rejects API keys at
+// /api/v2/auth/login and /api/v2/auth/logout.
+func NewClientWithAPIKey(baseURL, apiKey string) (*Client, error) {
+	jar, err := cookiejar.New(nil)
+	if err != nil {
+		return nil, NewValidationError("failed to create cookie jar", err)
+	}
+
+	return &Client{
+		baseURL: strings.TrimRight(baseURL, "/"),
+		httpClient: &http.Client{
+			Jar:       jar,
+			Timeout:   10 * time.Second,
+			Transport: &bearerAuthTransport{key: apiKey, base: http.DefaultTransport},
 		},
 	}, nil
 }

--- a/internal/api/client.go
+++ b/internal/api/client.go
@@ -29,17 +29,27 @@ func isSuccessStatus(code int) bool {
 	return code >= 200 && code < 300
 }
 
-// bearerAuthTransport injects "Authorization: Bearer <key>" on every outgoing
-// request. Used for qBittorrent's stateless API-key auth (≥5.2.0). Per the
-// qBittorrent docs, API keys cannot be used against /api/v2/auth/login or
-// /api/v2/auth/logout, so a client built with this transport must not call
-// Login.
+// bearerAuthTransport injects "Authorization: Bearer <key>" on requests
+// targeting host, the host of the configured qBittorrent server. Used for
+// qBittorrent's stateless API-key auth (≥5.2.0). Per the qBittorrent docs,
+// API keys cannot be used against /api/v2/auth/login or /api/v2/auth/logout,
+// so a client built with this transport must not call Login.
+//
+// The host gate matters because net/http's built-in protection that strips
+// Authorization on a cross-host redirect only applies to headers set on the
+// original request — headers added inside a RoundTripper would otherwise be
+// re-attached on every follow-up, leaking the key if a server or proxy
+// redirected to a different origin.
 type bearerAuthTransport struct {
 	key  string
+	host string
 	base http.RoundTripper
 }
 
 func (t *bearerAuthTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	if req.URL.Host != t.host {
+		return t.base.RoundTrip(req)
+	}
 	clone := req.Clone(req.Context())
 	clone.Header.Set("Authorization", "Bearer "+t.key)
 	return t.base.RoundTrip(clone)
@@ -62,21 +72,24 @@ func NewClient(baseURL string) (*Client, error) {
 
 // NewClientWithAPIKey returns a Client that authenticates via qBittorrent's
 // stateless API-key mechanism (≥5.2.0). The key is sent as an
-// "Authorization: Bearer <key>" header on every request. Callers must not
-// invoke Login on a client built this way — qBittorrent rejects API keys at
-// /api/v2/auth/login and /api/v2/auth/logout.
+// "Authorization: Bearer <key>" header on requests to the configured host.
+// No cookie jar is attached — API-key auth is stateless by design, and
+// keeping the jar nil prevents a proxy or future server change from
+// establishing a session cookie behind our back.
+//
+// Callers must not invoke Login on a client built this way — qBittorrent
+// rejects API keys at /api/v2/auth/login and /api/v2/auth/logout.
 func NewClientWithAPIKey(baseURL, apiKey string) (*Client, error) {
-	jar, err := cookiejar.New(nil)
-	if err != nil {
-		return nil, NewValidationError("failed to create cookie jar", err)
+	u, err := url.Parse(baseURL)
+	if err != nil || u.Host == "" {
+		return nil, NewValidationError("invalid base URL", err)
 	}
 
 	return &Client{
 		baseURL: strings.TrimRight(baseURL, "/"),
 		httpClient: &http.Client{
-			Jar:       jar,
 			Timeout:   10 * time.Second,
-			Transport: &bearerAuthTransport{key: apiKey, base: http.DefaultTransport},
+			Transport: &bearerAuthTransport{key: apiKey, host: u.Host, base: http.DefaultTransport},
 		},
 	}, nil
 }

--- a/internal/api/client_integration_test.go
+++ b/internal/api/client_integration_test.go
@@ -33,6 +33,10 @@ func TestClientIntegration(t *testing.T) {
 		t.Log("Authentication is bypassed - using subnet whitelist")
 	}
 
+	// API-key auth (qBittorrent ≥5.2.0) is preferred when QBT_TEST_API_KEY is
+	// set; it skips the user/pass login flow entirely.
+	apiKey := os.Getenv("QBT_TEST_API_KEY")
+
 	// Use credentials from environment or defaults
 	username := os.Getenv("QBT_TEST_USERNAME")
 	if username == "" {
@@ -40,14 +44,14 @@ func TestClientIntegration(t *testing.T) {
 	}
 
 	password := os.Getenv("QBT_TEST_PASSWORD")
-	if password == "" && !authBypassed {
-		t.Fatal("QBT_TEST_PASSWORD environment variable is required when auth is not bypassed.")
+	if password == "" && !authBypassed && apiKey == "" {
+		t.Fatal("QBT_TEST_PASSWORD environment variable is required when auth is not bypassed and QBT_TEST_API_KEY is unset.")
 	}
 	if password == "" {
 		password = "dummy" // Won't be used but API client expects something
 	}
 
-	t.Logf("Testing with URL: %s, Auth bypassed: %v", serverURL, authBypassed)
+	t.Logf("Testing with URL: %s, Auth bypassed: %v, API key: %v", serverURL, authBypassed, apiKey != "")
 
 	// First check if the server is reachable
 	resp2, err2 := http.Get(serverURL)
@@ -56,22 +60,32 @@ func TestClientIntegration(t *testing.T) {
 	}
 	resp2.Body.Close()
 
-	client, err := NewClient(serverURL)
-	require.NoError(t, err)
+	var client *Client
+	if apiKey != "" {
+		c, err := NewClientWithAPIKey(serverURL, apiKey)
+		require.NoError(t, err)
+		client = c
+	} else {
+		c, err := NewClient(serverURL)
+		require.NoError(t, err)
+		client = c
+	}
 
 	ctx := context.Background()
 
-	t.Run("Login", func(t *testing.T) {
-		err := client.Login(username, password)
-		if authBypassed && err != nil {
-			// Login might fail but API calls should still work
-			t.Logf("Login returned error (expected with auth bypass): %v", err)
-		} else if !authBypassed && err != nil {
-			t.Fatalf("Login failed: %v", err)
-		} else {
-			t.Log("Login successful")
-		}
-	})
+	if apiKey == "" {
+		t.Run("Login", func(t *testing.T) {
+			err := client.Login(username, password)
+			if authBypassed && err != nil {
+				// Login might fail but API calls should still work
+				t.Logf("Login returned error (expected with auth bypass): %v", err)
+			} else if !authBypassed && err != nil {
+				t.Fatalf("Login failed: %v", err)
+			} else {
+				t.Log("Login successful")
+			}
+		})
+	}
 
 	t.Run("GetTorrents", func(t *testing.T) {
 		torrents, err := client.GetTorrents(ctx)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -150,11 +150,13 @@ func TestClientAPIKeyHostMismatch(t *testing.T) {
 	resp, err := tr.RoundTrip(matching)
 	require.NoError(t, err)
 	assert.Equal(t, "Bearer "+key, resp.Request.Header.Get("Authorization"), "matching host should carry the bearer token")
+	resp.Body.Close()
 
 	foreign, _ := http.NewRequest(http.MethodGet, "http://evil.example.com/steal", nil)
 	resp, err = tr.RoundTrip(foreign)
 	require.NoError(t, err)
 	assert.Empty(t, resp.Request.Header.Get("Authorization"), "foreign host must not receive the bearer token")
+	resp.Body.Close()
 }
 
 type roundTripperFunc func(*http.Request) (*http.Response, error)

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -26,6 +26,76 @@ func TestNewClient(t *testing.T) {
 	assert.NotNil(t, client.httpClient.Jar)
 }
 
+func TestNewClientWithAPIKey(t *testing.T) {
+	client, err := NewClientWithAPIKey("http://localhost:8080/", "qbt_testkeytestkeytestkeytestkey")
+	require.NoError(t, err)
+	assert.NotNil(t, client)
+	assert.Equal(t, "http://localhost:8080", client.baseURL, "trailing slash should be trimmed")
+	assert.NotNil(t, client.httpClient)
+	assert.NotNil(t, client.httpClient.Jar)
+	require.NotNil(t, client.httpClient.Transport, "transport should be wired for bearer auth")
+	bt, ok := client.httpClient.Transport.(*bearerAuthTransport)
+	require.True(t, ok, "transport should be *bearerAuthTransport")
+	assert.Equal(t, "qbt_testkeytestkeytestkeytestkey", bt.key)
+}
+
+// TestClientAPIKeyHeader verifies that a client built with NewClientWithAPIKey
+// sends "Authorization: Bearer <key>" on every outgoing request — both reads
+// and write actions — and that no session cookie is established (qBittorrent's
+// API-key auth is stateless).
+func TestClientAPIKeyHeader(t *testing.T) {
+	const key = "qbt_testkeytestkeytestkeytestkey"
+	wantAuth := "Bearer " + key
+
+	cases := []struct {
+		name string
+		path string
+		call func(c *Client, ctx context.Context) error
+	}{
+		{"GetTorrents", "/api/v2/torrents/info", func(c *Client, ctx context.Context) error {
+			_, err := c.GetTorrents(ctx)
+			return err
+		}},
+		{"PauseTorrents", "/api/v2/torrents/stop", func(c *Client, ctx context.Context) error {
+			return c.PauseTorrents(ctx, []string{"hash1"})
+		}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var sawAuth string
+			var sawCookies []*http.Cookie
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				assert.Equal(t, tc.path, r.URL.Path)
+				sawAuth = r.Header.Get("Authorization")
+				sawCookies = r.Cookies()
+				// GetTorrents needs a JSON body; the action endpoint is fine with 204.
+				if r.Method == http.MethodGet {
+					w.WriteHeader(http.StatusOK)
+					w.Write([]byte("[]"))
+					return
+				}
+				w.WriteHeader(http.StatusNoContent)
+			}))
+			defer server.Close()
+
+			client, err := NewClientWithAPIKey(server.URL, key)
+			require.NoError(t, err)
+
+			err = tc.call(client, context.Background())
+			require.NoError(t, err)
+
+			assert.Equal(t, wantAuth, sawAuth, "Authorization header missing or wrong")
+			assert.Empty(t, sawCookies, "API-key auth must not send cookies")
+
+			// Cookie jar should also be empty after the call — the server
+			// never issues a session cookie under API-key auth.
+			serverURL, _ := url.Parse(server.URL)
+			assert.Empty(t, client.httpClient.Jar.Cookies(serverURL), "cookie jar should stay empty")
+		})
+	}
+}
+
 func TestLoginWithActualServer(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping actual server test in short mode")

--- a/internal/api/client_test.go
+++ b/internal/api/client_test.go
@@ -32,11 +32,17 @@ func TestNewClientWithAPIKey(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.Equal(t, "http://localhost:8080", client.baseURL, "trailing slash should be trimmed")
 	assert.NotNil(t, client.httpClient)
-	assert.NotNil(t, client.httpClient.Jar)
+	assert.Nil(t, client.httpClient.Jar, "API-key clients should not attach a cookie jar")
 	require.NotNil(t, client.httpClient.Transport, "transport should be wired for bearer auth")
 	bt, ok := client.httpClient.Transport.(*bearerAuthTransport)
 	require.True(t, ok, "transport should be *bearerAuthTransport")
 	assert.Equal(t, "qbt_testkeytestkeytestkeytestkey", bt.key)
+	assert.Equal(t, "localhost:8080", bt.host, "transport host gate should match base URL host")
+}
+
+func TestNewClientWithAPIKeyInvalidURL(t *testing.T) {
+	_, err := NewClientWithAPIKey("not a url", "qbt_x")
+	assert.Error(t, err)
 }
 
 // TestClientAPIKeyHeader verifies that a client built with NewClientWithAPIKey
@@ -87,14 +93,73 @@ func TestClientAPIKeyHeader(t *testing.T) {
 
 			assert.Equal(t, wantAuth, sawAuth, "Authorization header missing or wrong")
 			assert.Empty(t, sawCookies, "API-key auth must not send cookies")
-
-			// Cookie jar should also be empty after the call — the server
-			// never issues a session cookie under API-key auth.
-			serverURL, _ := url.Parse(server.URL)
-			assert.Empty(t, client.httpClient.Jar.Cookies(serverURL), "cookie jar should stay empty")
 		})
 	}
 }
+
+// TestClientAPIKeyIgnoresSetCookie verifies that even if the server emits a
+// Set-Cookie header, the API-key client neither stores it nor replays it on
+// subsequent requests — the jar is nil, so there is no persistence surface.
+func TestClientAPIKeyIgnoresSetCookie(t *testing.T) {
+	const key = "qbt_testkeytestkeytestkeytestkey"
+
+	var requestCount int
+	var sawCookiesPerRequest [][]*http.Cookie
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount++
+		sawCookiesPerRequest = append(sawCookiesPerRequest, r.Cookies())
+		// Try to plant a cookie. A nil jar should drop it on the floor.
+		http.SetCookie(w, &http.Cookie{Name: "SID", Value: "should-not-persist", Path: "/"})
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("[]"))
+	}))
+	defer server.Close()
+
+	client, err := NewClientWithAPIKey(server.URL, key)
+	require.NoError(t, err)
+
+	ctx := context.Background()
+	_, err = client.GetTorrents(ctx)
+	require.NoError(t, err)
+	_, err = client.GetTorrents(ctx)
+	require.NoError(t, err)
+
+	require.Equal(t, 2, requestCount, "expected two server-observed requests")
+	assert.Empty(t, sawCookiesPerRequest[0], "first request must not send cookies")
+	assert.Empty(t, sawCookiesPerRequest[1], "second request must not replay a server-issued cookie")
+	assert.Nil(t, client.httpClient.Jar, "client must not grow a cookie jar")
+}
+
+// TestClientAPIKeyHostMismatch verifies the transport drops the Authorization
+// header for requests whose host doesn't match the configured base URL host.
+// This protects against credential leaks on cross-host redirects, which Go's
+// built-in protection cannot strip when the header is added inside a
+// RoundTripper rather than on the original request.
+func TestClientAPIKeyHostMismatch(t *testing.T) {
+	const key = "qbt_testkeytestkeytestkeytestkey"
+
+	tr := &bearerAuthTransport{
+		key:  key,
+		host: "qbittorrent.example.com:8080",
+		base: roundTripperFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{StatusCode: 200, Body: http.NoBody, Header: make(http.Header), Request: req}, nil
+		}),
+	}
+
+	matching, _ := http.NewRequest(http.MethodGet, "http://qbittorrent.example.com:8080/api/v2/torrents/info", nil)
+	resp, err := tr.RoundTrip(matching)
+	require.NoError(t, err)
+	assert.Equal(t, "Bearer "+key, resp.Request.Header.Get("Authorization"), "matching host should carry the bearer token")
+
+	foreign, _ := http.NewRequest(http.MethodGet, "http://evil.example.com/steal", nil)
+	resp, err = tr.RoundTrip(foreign)
+	require.NoError(t, err)
+	assert.Empty(t, resp.Request.Header.Get("Authorization"), "foreign host must not receive the bearer token")
+}
+
+type roundTripperFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripperFunc) RoundTrip(req *http.Request) (*http.Response, error) { return f(req) }
 
 func TestLoginWithActualServer(t *testing.T) {
 	if testing.Short() {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,12 +13,17 @@ import (
 	"github.com/spf13/viper"
 )
 
+// ServerConfig holds qBittorrent connection settings. Authenticate with
+// either Username+Password OR APIKey (qBittorrent ≥5.2.0) — not both.
+type ServerConfig struct {
+	URL      string `mapstructure:"url"`
+	Username string `mapstructure:"username"`
+	Password string `mapstructure:"password"`
+	APIKey   string `mapstructure:"api_key"`
+}
+
 type Config struct {
-	Server struct {
-		URL      string `mapstructure:"url"`
-		Username string `mapstructure:"username"`
-		Password string `mapstructure:"password"`
-	} `mapstructure:"server"`
+	Server ServerConfig `mapstructure:"server"`
 
 	UI struct {
 		RefreshInterval int      `mapstructure:"refresh_interval"`
@@ -63,6 +68,7 @@ func Load(cmd *cobra.Command) (*Config, error) {
 	viper.BindEnv("server.url", "QBT_SERVER_URL")
 	viper.BindEnv("server.username", "QBT_SERVER_USERNAME")
 	viper.BindEnv("server.password", "QBT_SERVER_PASSWORD")
+	viper.BindEnv("server.api_key", "QBT_SERVER_API_KEY")
 	viper.BindEnv("ui.refresh_interval", "QBT_UI_REFRESH_INTERVAL")
 	viper.BindEnv("ui.columns", "QBT_UI_COLUMNS")
 	viper.BindEnv("ui.default_sort.column", "QBT_UI_DEFAULT_SORT_COLUMN")
@@ -101,6 +107,9 @@ func Load(cmd *cobra.Command) (*Config, error) {
 		if err := bindFlag("server.password", "password"); err != nil {
 			return nil, err
 		}
+		if err := bindFlag("server.api_key", "api-key"); err != nil {
+			return nil, err
+		}
 		if err := bindFlag("ui.refresh_interval", "refresh"); err != nil {
 			return nil, err
 		}
@@ -127,6 +136,10 @@ func Load(cmd *cobra.Command) (*Config, error) {
 func (c *Config) validate() error {
 	if c.Server.URL == "" {
 		return fmt.Errorf("server.url is required")
+	}
+
+	if c.Server.APIKey != "" && (c.Server.Username != "" || c.Server.Password != "") {
+		return fmt.Errorf("server.api_key cannot be combined with server.username or server.password — choose one auth method")
 	}
 
 	if c.UI.RefreshInterval < 1 {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -93,6 +93,39 @@ refresh_interval = 0`,
 			wantErr:     true,
 			errContains: "refresh_interval must be at least 1 second",
 		},
+		{
+			name: "api_key in config file",
+			configData: `[server]
+url = "http://localhost:8080"
+api_key = "qbt_testkeytestkeytestkeytestkey"`,
+			wantErr: false,
+			validate: func(t *testing.T, cfg *Config) {
+				assert.Equal(t, "qbt_testkeytestkeytestkeytestkey", cfg.Server.APIKey)
+				assert.Empty(t, cfg.Server.Username)
+				assert.Empty(t, cfg.Server.Password)
+			},
+		},
+		{
+			name: "api_key via env var",
+			configData: `[server]
+url = "http://localhost:8080"`,
+			envVars: map[string]string{
+				"QBT_SERVER_API_KEY": "qbt_envkeyenvkeyenvkeyenvkeyenvk",
+			},
+			wantErr: false,
+			validate: func(t *testing.T, cfg *Config) {
+				assert.Equal(t, "qbt_envkeyenvkeyenvkeyenvkeyenvk", cfg.Server.APIKey)
+			},
+		},
+		{
+			name: "api_key conflicts with username in config file",
+			configData: `[server]
+url = "http://localhost:8080"
+username = "admin"
+api_key = "qbt_testkeytestkeytestkeytestkey"`,
+			wantErr:     true,
+			errContains: "server.api_key cannot be combined",
+		},
 	}
 
 	for _, tt := range tests {
@@ -147,11 +180,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "valid config",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -195,11 +224,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "invalid refresh interval",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -223,11 +248,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "invalid default sort column",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -257,11 +278,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "invalid default sort direction",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -292,11 +309,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "valid default sort",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -326,11 +339,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "invalid terminal title template",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -361,11 +370,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "valid terminal title template",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -395,11 +400,7 @@ func TestConfigValidation(t *testing.T) {
 		{
 			name: "empty terminal title template is valid",
 			config: Config{
-				Server: struct {
-					URL      string `mapstructure:"url"`
-					Username string `mapstructure:"username"`
-					Password string `mapstructure:"password"`
-				}{
+				Server: ServerConfig{
 					URL: "http://localhost:8080",
 				},
 				UI: struct {
@@ -425,6 +426,82 @@ func TestConfigValidation(t *testing.T) {
 				},
 			},
 			wantErr: false,
+		},
+		{
+			name: "api_key alone is valid",
+			config: Config{
+				Server: ServerConfig{
+					URL:    "http://localhost:8080",
+					APIKey: "qbt_testkeytestkeytestkeytestkey",
+				},
+				UI: struct {
+					RefreshInterval int      `mapstructure:"refresh_interval"`
+					Columns         []string `mapstructure:"columns"`
+					DefaultSort     struct {
+						Column    string `mapstructure:"column"`
+						Direction string `mapstructure:"direction"`
+					} `mapstructure:"default_sort"`
+					TerminalTitle struct {
+						Enabled  bool   `mapstructure:"enabled"`
+						Template string `mapstructure:"template"`
+					} `mapstructure:"terminal_title"`
+				}{
+					RefreshInterval: 3,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "api_key combined with username is rejected",
+			config: Config{
+				Server: ServerConfig{
+					URL:      "http://localhost:8080",
+					Username: "admin",
+					APIKey:   "qbt_testkeytestkeytestkeytestkey",
+				},
+				UI: struct {
+					RefreshInterval int      `mapstructure:"refresh_interval"`
+					Columns         []string `mapstructure:"columns"`
+					DefaultSort     struct {
+						Column    string `mapstructure:"column"`
+						Direction string `mapstructure:"direction"`
+					} `mapstructure:"default_sort"`
+					TerminalTitle struct {
+						Enabled  bool   `mapstructure:"enabled"`
+						Template string `mapstructure:"template"`
+					} `mapstructure:"terminal_title"`
+				}{
+					RefreshInterval: 3,
+				},
+			},
+			wantErr: true,
+			errMsg:  "server.api_key cannot be combined",
+		},
+		{
+			name: "api_key combined with password is rejected",
+			config: Config{
+				Server: ServerConfig{
+					URL:      "http://localhost:8080",
+					Password: "secret",
+					APIKey:   "qbt_testkeytestkeytestkeytestkey",
+				},
+				UI: struct {
+					RefreshInterval int      `mapstructure:"refresh_interval"`
+					Columns         []string `mapstructure:"columns"`
+					DefaultSort     struct {
+						Column    string `mapstructure:"column"`
+						Direction string `mapstructure:"direction"`
+					} `mapstructure:"default_sort"`
+					TerminalTitle struct {
+						Enabled  bool   `mapstructure:"enabled"`
+						Template string `mapstructure:"template"`
+					} `mapstructure:"terminal_title"`
+				}{
+					RefreshInterval: 3,
+				},
+			},
+			wantErr: true,
+			errMsg:  "server.api_key cannot be combined",
 		},
 	}
 

--- a/internal/logger/sync.go
+++ b/internal/logger/sync.go
@@ -234,7 +234,7 @@ func formatPartialTorrent(partial *api.PartialTorrent) []any {
 
 	for i := 0; i < v.NumField(); i++ {
 		field := v.Field(i)
-		if field.Kind() == reflect.Ptr && !field.IsNil() {
+		if field.Kind() == reflect.Pointer && !field.IsNil() {
 			// Get JSON tag for field name, fall back to lowercase field name
 			fieldName := t.Field(i).Tag.Get("json")
 			if fieldName == "" {


### PR DESCRIPTION
## Summary

Adds support for qBittorrent 5.2.0+ [API-key authentication](https://github.com/qbittorrent/qBittorrent/wiki/API-Key-Authentication-(%E2%89%A5v5.2.0)) as an alternative to the existing username/password + cookie login flow.

## Why

API keys let users authenticate without storing a plaintext password on disk, are revocable per-app from the WebUI, and skip the `/api/v2/auth/login` round-trip entirely (stateless — no session cookie). They're the recommended auth path going forward for headless / config-file deployments like this TUI.

## Changes

- **`internal/api/client.go`** — new `bearerAuthTransport` (`http.RoundTripper`) injects `Authorization: Bearer <key>` on every request. New `NewClientWithAPIKey(baseURL, apiKey)` constructor wires it in. Existing `NewClient`/`Login` path is untouched, so user/pass users see zero change.
- **`internal/config/config.go`** — added `APIKey` field to a new named `ServerConfig` type (extracted from the previous inline anon struct), `QBT_SERVER_API_KEY` env binding, `--api-key` flag binding, and a mutual-exclusion check in `validate()` that errors out if `api_key` is combined with `username` or `password`. Configuring both would be ambiguous, so we fail fast with a clear message.
- **`cmd/qbt-tui/main.go`** — `--api-key` flag, env doc, and a branch in `run()` so the API-key path uses `NewClientWithAPIKey` and **does not** call `Login()` (per the qBittorrent docs, API keys are rejected at `/auth/login` and `/auth/logout`).
- **Tests** — `TestNewClientWithAPIKey` (constructor wiring), `TestClientAPIKeyHeader` (`Authorization: Bearer …` on both read and write endpoints; empty cookie jar), plus new config cases covering file, env, validation-pass, and validation-fail.
- **Integration test** — honors `QBT_TEST_API_KEY`; when set, builds via `NewClientWithAPIKey` and skips the `Login` subtest.
- **README** — new Authentication section, env var + flag docs, and the mutual-exclusion warning.

## Design notes

- **Conflict behavior:** mixing `api_key` with `username`/`password` is rejected at startup rather than silently preferring one. Forces an explicit choice and keeps misconfiguration loud.
- **No startup probe:** an invalid key surfaces naturally on the first real request through the existing `NewAuthError` path in the `get` helper, so no separate verification call is needed.
- **Centralized header injection:** done via a transport wrapper rather than adding `req.Header.Set(...)` at each call site, so future endpoints automatically pick up auth.