### PR TITLE
Handle bracketed paste in text input dialogs

### DIFF
--- a/internal/ui/components/filter_panel.go
+++ b/internal/ui/components/filter_panel.go
@@ -163,6 +163,11 @@ func (f *FilterPanel) Update(msg tea.Msg) (*FilterPanel, tea.Cmd) {
 				f.clearFilters()
 			}
 		}
+
+	case tea.PasteMsg:
+		if f.mode == FilterModeSearch {
+			f.searchInput, cmd = f.searchInput.Update(msg)
+		}
 	}
 
 	return f, cmd

--- a/internal/ui/components/filter_panel_test.go
+++ b/internal/ui/components/filter_panel_test.go
@@ -279,3 +279,23 @@ func stripANSI(s string) string {
 	}
 	return result
 }
+
+func TestFilterPanel_PasteInSearchMode(t *testing.T) {
+	panel := NewFilterPanel()
+
+	// Enter search mode
+	panel, _ = panel.Update(keyPress('/'))
+	assert.Equal(t, FilterModeSearch, panel.mode)
+
+	// Paste text
+	panel, _ = panel.Update(tea.PasteMsg{Content: "ubuntu"})
+	assert.Equal(t, "ubuntu", panel.searchInput.Value())
+}
+
+func TestFilterPanel_PasteIgnoredOutsideSearchMode(t *testing.T) {
+	panel := NewFilterPanel()
+	assert.Equal(t, FilterModeNone, panel.mode)
+
+	panel, _ = panel.Update(tea.PasteMsg{Content: "ignored"})
+	assert.Equal(t, "", panel.searchInput.Value())
+}

--- a/internal/ui/views/main.go
+++ b/internal/ui/views/main.go
@@ -945,6 +945,17 @@ func (m *MainView) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 				cmds = append(cmds, cmd)
 			}
 		}
+
+	case tea.PasteMsg:
+		if m.showAddDialog && m.addDialog.mode == ModeURL {
+			m.addDialog.urlInput.url = appendPrintable(m.addDialog.urlInput.url, msg.Content)
+		} else if m.showLocationDialog && m.locationDialog.mode == LocationModeText {
+			m.locationDialog.pathInput.path = appendPrintable(m.locationDialog.pathInput.path, msg.Content)
+			m.locationDialog.pathInput.cursor = len(m.locationDialog.pathInput.path)
+		} else if m.filterPanel.IsInInputMode() {
+			m.filterPanel, cmd = m.filterPanel.Update(msg)
+			cmds = append(cmds, cmd)
+		}
 	}
 
 	return m, tea.Batch(cmds...)
@@ -1915,6 +1926,16 @@ func (m *MainView) handleFileNavigatorKeys(key string) tea.Cmd {
 	return nil
 }
 
+// appendPrintable appends only printable ASCII characters from s to dst.
+func appendPrintable(dst, s string) string {
+	for _, r := range s {
+		if r >= 32 && r <= 126 {
+			dst += string(r)
+		}
+	}
+	return dst
+}
+
 // handleURLInputKeys handles keyboard input for URL input
 func (m *MainView) handleURLInputKeys(keyMsg tea.KeyPressMsg) tea.Cmd {
 	urlInput := m.addDialog.urlInput
@@ -1929,18 +1950,10 @@ func (m *MainView) handleURLInputKeys(keyMsg tea.KeyPressMsg) tea.Cmd {
 			urlInput.url = urlInput.url[:len(urlInput.url)-1]
 		}
 	case "ctrl+a":
-		// Select all (clear field)
 		urlInput.url = ""
 	default:
-		// Handle character input - this includes paste operations
-		// Bubble Tea v2 provides the input as Text (string) instead of Runes
 		if len(keyMsg.Text) > 0 {
-			for _, r := range keyMsg.Text {
-				// Only add printable characters (includes all URL chars: :, /, ?, =, etc.)
-				if r >= 32 && r <= 126 {
-					urlInput.url += string(r)
-				}
-			}
+			urlInput.url = appendPrintable(urlInput.url, keyMsg.Text)
 		}
 	}
 
@@ -1962,24 +1975,15 @@ func (m *MainView) handlePathInputKeys(keyMsg tea.KeyPressMsg) tea.Cmd {
 			pathInput.cursor = len(pathInput.path)
 		}
 	case "ctrl+a":
-		// Select all (clear field)
 		pathInput.path = ""
 		pathInput.cursor = 0
 	case "ctrl+u":
-		// Clear to beginning of line
 		pathInput.path = ""
 		pathInput.cursor = 0
 	default:
-		// Handle character input - this includes paste operations
-		// Bubble Tea v2 provides the input as Text (string) instead of Runes
 		if len(keyMsg.Text) > 0 {
-			for _, r := range keyMsg.Text {
-				// Only add printable characters (includes path chars: /, -, _, etc.)
-				if r >= 32 && r <= 126 {
-					pathInput.path += string(r)
-					pathInput.cursor++
-				}
-			}
+			pathInput.path = appendPrintable(pathInput.path, keyMsg.Text)
+			pathInput.cursor = len(pathInput.path)
 		}
 	}
 

--- a/internal/ui/views/main.go
+++ b/internal/ui/views/main.go
@@ -1928,12 +1928,15 @@ func (m *MainView) handleFileNavigatorKeys(key string) tea.Cmd {
 
 // appendPrintable appends only printable ASCII characters from s to dst.
 func appendPrintable(dst, s string) string {
+	var b strings.Builder
+	b.Grow(len(dst) + len(s))
+	b.WriteString(dst)
 	for _, r := range s {
 		if r >= 32 && r <= 126 {
-			dst += string(r)
+			b.WriteRune(r)
 		}
 	}
-	return dst
+	return b.String()
 }
 
 // handleURLInputKeys handles keyboard input for URL input

--- a/internal/ui/views/main_paste_test.go
+++ b/internal/ui/views/main_paste_test.go
@@ -1,0 +1,121 @@
+package views
+
+import (
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+	"github.com/nickvanw/qbittorrent-tui/internal/api"
+	"github.com/nickvanw/qbittorrent-tui/internal/config"
+	"github.com/nickvanw/qbittorrent-tui/internal/ui/components"
+)
+
+func TestAppendPrintable(t *testing.T) {
+	tests := []struct {
+		name string
+		dst  string
+		s    string
+		want string
+	}{
+		{"empty", "", "", ""},
+		{"magnet link", "", "magnet:?xt=urn:btih:abc123&dn=test", "magnet:?xt=urn:btih:abc123&dn=test"},
+		{"appends to existing", "http://", "example.com/file.torrent", "http://example.com/file.torrent"},
+		{"strips non-ASCII", "", "hello\x00world\x01!", "helloworld!"},
+		{"strips high unicode", "", "testéfile", "testfile"},
+		{"preserves URL special chars", "", "https://a.co/path?q=1&x=2#frag", "https://a.co/path?q=1&x=2#frag"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := appendPrintable(tt.dst, tt.s)
+			if got != tt.want {
+				t.Errorf("appendPrintable(%q, %q) = %q, want %q", tt.dst, tt.s, got, tt.want)
+			}
+		})
+	}
+}
+
+func newTestMainView() *MainView {
+	cfg := &config.Config{}
+	return &MainView{
+		config:      cfg,
+		torrentList: components.NewTorrentListWithColumns(nil, "", ""),
+		statsPanel:  components.NewStatsPanel(),
+		filterPanel: components.NewFilterPanel(),
+		keys:        DefaultKeyMap(),
+		viewMode:    ViewModeMain,
+		addDialog: &AddTorrentDialog{
+			mode:     ModeURL,
+			urlInput: &URLInput{url: "", cursor: 0},
+		},
+		torrentMap: make(map[string]api.Torrent),
+	}
+}
+
+func TestPasteIntoURLInput(t *testing.T) {
+	m := newTestMainView()
+	m.showAddDialog = true
+	m.addDialog.mode = ModeURL
+
+	magnet := "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&dn=test"
+	m.Update(tea.PasteMsg{Content: magnet})
+
+	if m.addDialog.urlInput.url != magnet {
+		t.Errorf("paste into URL input: got %q, want %q", m.addDialog.urlInput.url, magnet)
+	}
+}
+
+func TestPasteIntoURLInputAppends(t *testing.T) {
+	m := newTestMainView()
+	m.showAddDialog = true
+	m.addDialog.mode = ModeURL
+	m.addDialog.urlInput.url = "http://"
+
+	m.Update(tea.PasteMsg{Content: "example.com/file.torrent"})
+
+	want := "http://example.com/file.torrent"
+	if m.addDialog.urlInput.url != want {
+		t.Errorf("paste append: got %q, want %q", m.addDialog.urlInput.url, want)
+	}
+}
+
+func TestPasteIntoPathInput(t *testing.T) {
+	m := newTestMainView()
+	m.showLocationDialog = true
+	m.locationDialog = &LocationDialog{
+		mode:      LocationModeText,
+		pathInput: &PathInput{path: "", cursor: 0},
+	}
+
+	path := "/mnt/data/downloads"
+	m.Update(tea.PasteMsg{Content: path})
+
+	if m.locationDialog.pathInput.path != path {
+		t.Errorf("paste into path input: got %q, want %q", m.locationDialog.pathInput.path, path)
+	}
+	if m.locationDialog.pathInput.cursor != len(path) {
+		t.Errorf("cursor after paste: got %d, want %d", m.locationDialog.pathInput.cursor, len(path))
+	}
+}
+
+func TestPasteIgnoredWhenNoInputActive(t *testing.T) {
+	m := newTestMainView()
+	m.showAddDialog = false
+	m.showLocationDialog = false
+
+	m.Update(tea.PasteMsg{Content: "should be ignored"})
+
+	if m.addDialog.urlInput.url != "" {
+		t.Error("paste should be ignored when no dialog is open")
+	}
+}
+
+func TestPasteIgnoredInFileMode(t *testing.T) {
+	m := newTestMainView()
+	m.showAddDialog = true
+	m.addDialog.mode = ModeFile
+
+	m.Update(tea.PasteMsg{Content: "should be ignored"})
+
+	if m.addDialog.urlInput.url != "" {
+		t.Error("paste should be ignored when add dialog is in file mode")
+	}
+}

--- a/internal/ui/views/main_paste_test.go
+++ b/internal/ui/views/main_paste_test.go
@@ -119,3 +119,50 @@ func TestPasteIgnoredInFileMode(t *testing.T) {
 		t.Error("paste should be ignored when add dialog is in file mode")
 	}
 }
+
+func TestPasteIntoFilterSearch(t *testing.T) {
+	m := newTestMainView()
+
+	// Enter filter search mode (press '/')
+	m.filterPanel, _ = m.filterPanel.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+	if !m.filterPanel.IsInInputMode() {
+		t.Fatal("filter panel should be in search mode")
+	}
+
+	m.Update(tea.PasteMsg{Content: "ubuntu"})
+
+	if m.filterPanel.GetFilter().Search != "" {
+		t.Error("search filter should not be committed until Enter is pressed")
+	}
+
+	// Press Enter to commit the search
+	m.filterPanel, _ = m.filterPanel.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+
+	if m.filterPanel.GetFilter().Search != "ubuntu" {
+		t.Errorf("filter search after paste+enter: got %q, want %q", m.filterPanel.GetFilter().Search, "ubuntu")
+	}
+}
+
+func TestPasteFilterSearchIgnoredWhenDialogOpen(t *testing.T) {
+	m := newTestMainView()
+
+	// Enter filter search mode
+	m.filterPanel, _ = m.filterPanel.Update(tea.KeyPressMsg{Code: '/', Text: "/"})
+
+	// Open add dialog — it should take priority over the filter panel
+	m.showAddDialog = true
+	m.addDialog.mode = ModeURL
+
+	m.Update(tea.PasteMsg{Content: "magnet:?xt=test"})
+
+	// Paste should go to the URL input, not the filter
+	if m.addDialog.urlInput.url != "magnet:?xt=test" {
+		t.Errorf("paste should go to URL input when dialog is open, got %q", m.addDialog.urlInput.url)
+	}
+
+	// Confirm filter search was NOT updated
+	m.filterPanel, _ = m.filterPanel.Update(tea.KeyPressMsg{Code: tea.KeyEnter})
+	if m.filterPanel.GetFilter().Search != "" {
+		t.Error("filter search should not receive paste when add dialog is open")
+	}
+}


### PR DESCRIPTION
## Summary

- Bubble Tea v2 delivers terminal paste (e.g. `Ctrl+Shift+V`, `Shift+Insert`) as `tea.PasteMsg`, but `MainView.Update` only handled `tea.KeyPressMsg` — so pasted content was silently dropped. This made it impossible to paste magnet links or URLs into the add-torrent dialog.
- Added a `tea.PasteMsg` case that routes pasted text to whichever input is active: URL input (add dialog), path input (location dialog), or filter search.
- Extracted the printable-ASCII filter into a shared `appendPrintable` helper, reused by both the paste handler and the existing typed-key handlers.

Closes #48